### PR TITLE
Fixing lang graph version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ langchain==0.3.25
 langchain-community==0.3.23
 langchain-core==0.3.58
 langchain-nvidia-ai-endpoints==0.3.10
-langgraph==0.4.1
+langgraph==0.5.3
 streamlit==1.45.0


### PR DESCRIPTION
Issue:

The current code doesn't work, and hits the following error:
```
TypeError: StateGraph.add_node() got an unexpected keyword argument 'input_schema'
```

Thanks to @yucthonni, I along with many others were able to get it work by changing the langgraph version from `0.4.1` to `0.5.3`

ref: https://github.com/bubbleran/Telco-Network-Configuration/issues/2#issuecomment-3117193702